### PR TITLE
#171894190 user updates specific fields

### DIFF
--- a/src/components/trips/Oneway.js
+++ b/src/components/trips/Oneway.js
@@ -41,7 +41,6 @@ export const disabledHandler = (props, state) => {
 // ⚠️ No support for IE 11
 export const countryToFlag = isoCode =>
   isoCode.toUpperCase().replace(/./g, char => String.fromCodePoint(char.charCodeAt(0) + 127397));
-
 const OneWay = () => {
   const oneWayTripSchema = Yup.object({
     origin: Yup.string().required('Origin is required'),

--- a/src/components/trips/editTrip.js
+++ b/src/components/trips/editTrip.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-sequences */
 /* eslint-disable no-unused-expressions */
 /* eslint-disable no-unused-vars */
 /* eslint-disable max-len */
@@ -27,14 +28,24 @@ import { getAllTripRequests, getAllTripLocations } from '../../redux/actions/req
 import Loading from '../common/loading';
 
 export const disabledHandler = (props, state) => {
+  const formatDate = dt => {
+    const month = `0${dt.getMonth() + 1}`.slice(-2);
+    const date = `0${dt.getDate()}`.slice(-2);
+    const formattedDate = `${dt.getFullYear()}-${month}-${date}`;
+    return formattedDate;
+  };
+  const date1 = formatDate(props.values.departureDate)
+  const date2 = formatDate(new Date());
+  const date4 = formatDate(new Date(props.values.returnDate));
+  const date3 = formatDate(new Date(new Date().setDate(new Date().getDate() + 1)));
   if (
-    !props.values.origin ||
-    !props.values.destination ||
-    !props.values.departureDate ||
-    // !props.values.returnDate ||
-    !props.values.travelReasons ||
-    state.loading ||
-    Object.keys(props.errors).length !== 0
+    props.values.origin.country === undefined &&
+    props.values.destination.country === undefined &&
+    date1 === date2 &&
+    props.values.travelReasons === '' ||
+    state.loading &&
+    Object.keys(props.errors).length !== 0 ||
+    state.message === 'Trip Updated successfully'
   ) {
     return true;
   }
@@ -83,7 +94,7 @@ const EditTrip = () => {
   const tripReqId = queryString.parse(window.location.search);
   useEffect(() => {
     dispatch(getAllTripRequests());
-    // dispatch(getAllTripLocations());
+    dispatch(getAllTripLocations());
     dispatch(getLocations());
     dispatch(getAccommodations());
   }, []);
@@ -97,29 +108,6 @@ const EditTrip = () => {
       setMyTrip(findTrip)
     }
   }, [trips])
-
-  const locationsList = useSelector(state => state.tripLocationsReducer);
-  const allLocations = [...locationsList.data];
-
-  const [myOriginLocation, setMyOriginLocation] = useState([]);
-  React.useEffect(() => {
-    if (allLocations.length > 0) {
-      const findOriginLocation = allLocations.find(loc => loc.id === myTrip.originId);
-      setMyOriginLocation(findOriginLocation)
-    }
-  }, [allLocations])
-
-  const originCountry = myOriginLocation.country;
-
-  const [myDestinationLocation, setMyestinationLocation] = useState([]);
-  React.useEffect(() => {
-    if (allLocations.length > 0) {
-      const findDestinationLocation = allLocations.find(loc => loc.id === myTrip.destinationId);
-      setMyestinationLocation(findDestinationLocation)
-    }
-  }, [allLocations])
-
-  const destinationCountry = myDestinationLocation.country;
 
   const statee = useSelector(statees => statees.returnTripReducer);
   const countries = statee.locations
@@ -141,12 +129,11 @@ const EditTrip = () => {
     <div>
       <Formik
         initialValues={{
-          origin: myOriginLocation,
-          destination: myDestinationLocation,
+          origin: '',
+          destination: '',
           accommodation: '',
-          travelReasons: myTrip.travelReasons || '',
-          departureDate: new Date(),
-          // returnDate: new Date().setDate(new Date().getDate() + 1)
+          travelReasons: '',
+          departureDate: new Date()
         }}
         validationSchema={TripSchema}
         onSubmit={values => dispatch(editTripRequest(tripIds, values))}
@@ -167,9 +154,7 @@ const EditTrip = () => {
                       }}
                       name='origin'
                       autoHighlight
-                      onChange={(event, value) =>
-                        props.setFieldValue('origin', value)
-                      }
+                      onChange={(event, value) => props.setFieldValue('origin', value)}
                       getOptionLabel={option => option.country}
                       renderOption={option => (
                         <div data-test='locations'>
@@ -293,28 +278,6 @@ const EditTrip = () => {
                         helperText={props.values.departureDate !== '' && props.errors.departureDate}
                       />
                     </MuiPickersUtilsProvider>
-                  </Grid>
-                  <Grid item xs>
-                    <Autocomplete
-                      size='small'
-                      id='combo-box-demo'
-                      options={accommodations}
-                      getOptionLabel={option => option.name}
-                      onChange={(event, value) =>
-                        props.setFieldValue('accommodation', value)
-                      }
-                      style={{ minWidth: 220 }}
-                      name='accommodation'
-                      renderInput={params => (
-                        <TextField
-                          {...params}
-                          label='Accommodation'
-                          variant='outlined'
-                          fullWidth
-                          value={props.values.accommodation}
-                        />
-                      )}
-                    />
                   </Grid>
                   <Grid item xs>
                     <TextField

--- a/src/redux/actions/editTripAction.js
+++ b/src/redux/actions/editTripAction.js
@@ -10,26 +10,26 @@ export const formatDate = dt => {
   return formattedDate;
 };
 
-export const editTripRequest = (tripId, values) => {
-  let editTripRequestValue;
-  if (values.returnDate) {
-    editTripRequestValue = {
-      originId: values.origin.id,
-      destinationId: values.destination.id,
-      returnDate: formatDate(values.returnDate),
-      departureDate: formatDate(values.departureDate),
-      travelReasons: values.travelReasons,
+  export const editTripRequest = (tripId, values) =>{
+    let editTripRequestValue;
+    if (values.returnDate) {
+      editTripRequestValue = {
+        originId: values.origin.id,
+        destinationId: values.destination.id,
+        returnDate: formatDate(values.returnDate),
+        departureDate: formatDate(values.departureDate),
+        travelReasons: values.travelReasons,
+      }
+    } else {
+      editTripRequestValue = {
+        originId: values.origin.id,
+        destinationId: values.destination.id,
+        departureDate: formatDate(values.departureDate),
+        travelReasons: values.travelReasons,
+      }
     }
-  } else {
-    editTripRequestValue = {
-      originId: values.origin.id,
-      destinationId: values.destination.id,
-      departureDate: formatDate(values.departureDate),
-      travelReasons: values.travelReasons,
-    }
+    return {
+      type: UPDATE_TRIP,
+      payload: updateTripService(tripId, editTripRequestValue)
+    };
   }
-  return {
-    type: UPDATE_TRIP,
-    payload: updateTripService(tripId, editTripRequestValue)
-  };
-};

--- a/src/routes.js
+++ b/src/routes.js
@@ -18,7 +18,7 @@ import ApprovalsTable from './views/approvalsView';
 import commentsView from './views/CommentsView';
 import RequestDetailsView from './views/requestApprovalDetailsView';
 import Accommodations from './components/accommodation/booking/index';
-import editTripView from './views/editTripView';
+import EditTripView from './views/editTripView';
 
 const routes = [
 	{
@@ -118,7 +118,7 @@ const routes = [
 			{
 				path: '/trip/edit',
 				exact: true,
-				component: editTripView
+				component: EditTripView
 			},
 			{
 				component: () => <Redirect to='/errors/error-404' />

--- a/src/tests/components/__snapshots__/tripRequestsCard.test.js.snap
+++ b/src/tests/components/__snapshots__/tripRequestsCard.test.js.snap
@@ -104,6 +104,20 @@ exports[`Test On ProfilePicture Component render() Should Render ProfilePicture 
           }
         }
       />
+      <WithStyles(ForwardRef(Button))
+        color="primary"
+        disabled={false}
+        onClick={[Function]}
+        size="small"
+        style={
+          Object {
+            "marginLeft": "45px",
+          }
+        }
+        variant="contained"
+      >
+        Edit Trip
+      </WithStyles(ForwardRef(Button))>
     </p>
   </div>
   <WithStyles(ForwardRef(Divider)) />
@@ -115,6 +129,7 @@ exports[`Test On ProfilePicture Component render() Should Render ProfilePicture 
       Object {
         "alignSelf": "center",
         "margin": 10,
+        "width": "90%",
       }
     }
     variant="contained"

--- a/src/tests/components/editTripView.test.js
+++ b/src/tests/components/editTripView.test.js
@@ -1,0 +1,41 @@
+/* eslint-disable prettier/prettier */
+/* eslint-disable no-undef */
+import React from 'react';
+import { Provider } from 'react-redux';
+import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { BrowserRouter as Router } from 'react-router-dom';
+import configureStore from '../../redux/store';
+import EditTripView from '../../views/editTripView';
+
+describe('Test Edit Trip view', () => {
+  it('Should render the view', () => {
+    const theme = createMuiTheme({
+      palette: {
+        primary: {
+          main: '#0074D9'
+        }
+      },
+      overrides: {
+        MuiOutlinedInput: {
+          input: {
+            '&:-webkit-autofill': {
+              WebkitBoxShadow: '0 0 0 100px #fff inset',
+              WebkitTextFillColor: '#000000'
+            }
+          }
+        }
+      }
+    });
+    const store = configureStore();
+    const component = mount(
+      <Provider store={store}>
+        <ThemeProvider theme={theme}>
+          <Router>
+            <EditTripView />
+          </Router>
+        </ThemeProvider>
+      </Provider>
+    );
+    expect(component.length).toEqual(1);
+  });
+});

--- a/src/tests/reducers/editOpenTripReducer.test.js
+++ b/src/tests/reducers/editOpenTripReducer.test.js
@@ -1,0 +1,95 @@
+/* eslint-disable max-len */
+/* eslint-disable prettier/prettier */
+/* eslint-disable no-undef */
+import updateTripReducer from '../../redux/reducers/editTripReducer';
+import { UPDATE_TRIP } from '../../redux/actions/actionTypes';
+import { pending, fulfilled, rejected } from '../../helpers/utils/action.utils';
+
+describe('Update Open Trip Reducer', () => {
+  it('Should return unchanged initial state: Unknown actiontype', () => {
+    const action = { type: 'dummy_action' };
+    const initialState = {
+      newTrip: '',
+      loading: false,
+      message: ''
+    };
+    expect(updateTripReducer(undefined, action)).toEqual(initialState);
+  });
+
+  it('Should successfully change the initial state: FULFILLED', () => {
+    const action = {
+      type: fulfilled(UPDATE_TRIP),
+      payload: {
+        data: {
+          message: 'Trip Updated successfully',
+          data:
+          {
+            id: 4,
+            tripType: "multi-city",
+            requestId: 3,
+            userId: 1,
+            originId: 7,
+            destinationId: 6,
+            departureDate: "2020-03-19T00:00:00.000Z",
+            returnDate: null,
+            travelReasons: "",
+            accommodationId: 7,
+            createdAt: '2020-03-03T18:48:11.570Z',
+            updatedAt: '2020-03-03T19:41:47.660Z'
+          }
+        }
+      }
+    };
+    const expectedState = {
+      loading: false,
+      message: 'Trip Updated successfully',
+      newTrip: {
+        id: 4,
+        tripType: "multi-city",
+        requestId: 3,
+        userId: 1,
+        originId: 7,
+        destinationId: 6,
+        departureDate: "2020-03-19T00:00:00.000Z",
+        returnDate: null,
+        travelReasons: "",
+        accommodationId: 7,
+        createdAt: '2020-03-03T18:48:11.570Z',
+        updatedAt: '2020-03-03T19:41:47.660Z'
+      }
+    };
+    expect(updateTripReducer(undefined, action)).toEqual(expectedState);
+  });
+
+  it('Should Not change the initial state: PENDING', () => {
+    const action = {
+      type: pending(UPDATE_TRIP)
+    };
+    const expectedState = {
+      newTrip: '',
+      loading: true,
+      message: ''
+    };
+    expect(updateTripReducer(undefined, action)).toEqual(expectedState);
+  });
+
+  it('Should Not change the initial state: REJECTED', () => {
+    const action = {
+      type: rejected(UPDATE_TRIP),
+      payload: {
+        response: {
+          data: {
+            message: 'Trip not updated'
+          }
+        }
+      }
+    };
+    const expectedState = {
+      newTrip: '',
+      loading: false,
+      message: 'Trip not updated'
+    };
+    expect(updateTripReducer(undefined, action)).toEqual(expectedState);
+  });
+
+});

--- a/src/views/editTripView.js
+++ b/src/views/editTripView.js
@@ -11,7 +11,7 @@ const useStyles = makeStyles(theme => ({
     marginTop: theme.spacing(3)
   }
 }));
-export default function editTripView() {
+export default function EditTripView() {
   const classes = useStyles();
   const handleTabsChange = (event, value) => {
     history.push(value);


### PR DESCRIPTION
#### What does this PR do?
- allow a user to update specific fields
#### Description of Task to be completed?
- While updating an open trip request, a user should be able to edit only the fields he wants. Not mandatory to be able to submit an update after filling all fields of the form.
#### How should this be manually tested?
- Login on barefoot nomad
- Click `Trip Requests` link on the sidebar
- You get redirected to the page containing all trips you have created so far.
- Click on `EDIT TRIP` button on a certain trip, you will get redirected to a page where you can edit that trip by only changing those fields you want to get updated(Not mandatory to change all as it was in the previous [PR](https://github.com/andela/the_spinners-frontend/pull/50))
- Edit the fields you want and click `UPDATE A TRIP`

#### What are the relevant pivotal tracker stories?
[#171894190](https://www.pivotaltracker.com/story/show/171894190)
#### Screenshots
- After this bug fix
<img width="1440" alt="Screen Shot 2020-03-20 at 09 19 13" src="https://user-images.githubusercontent.com/58309608/77143452-ff090100-6a8b-11ea-9b3a-3778efdf258e.png">




